### PR TITLE
Ensure baseline prices retrieved for all symbols

### DIFF
--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -509,8 +509,8 @@ async function fetchYahooBaselines(symbols) {
     const v = out[String(s).toUpperCase()] || {};
     return !(Number.isFinite(v.prevClose) && (Number.isFinite(v.prevClose30d) || Number.isFinite(v.prevClose365d)));
   });
-  const limit = 15; // safe cap for additional per-symbol chart fetches
-  for (let i=0;i<Math.min(limit, missing.length);i++){
+  const limit = Math.min(50, symbols.length); // safe cap respecting Cloudflare subrequest limits
+  for (let i = 0; i < Math.min(limit, missing.length); i++){
     const s = missing[i];
     try{
       const r = await fetchYahooChart(s);


### PR DESCRIPTION
## Summary
- increase per-symbol baseline fallback limit in Cloudflare worker to handle larger symbol sets

## Testing
- `node -e "import('./proxy/worker.js').then(() => console.log('ok')).catch(err => {console.error(err); process.exit(1);});"`


------
https://chatgpt.com/codex/tasks/task_e_68b23ecf8fd0832b8e9847c0b0a22ca5