### PR TITLE
Add CSV-based portfolio display

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - `service-worker.js` — オフライン用の Service Worker
 - `manifest.webmanifest` — PWA 用マニフェスト
 - `proxy/worker.js` — Cloudflare Workers 用プロキシ API (任意)
+- `portfolio.csv` — ポートフォリオデータのサンプル CSV
+- `portfolio.html` — `portfolio.csv` を読み込んで表示するシンプルなページ
 
 ## 使い方
 1. GitHub Pages など任意の静的ホスティングに本リポジトリを配置します。

--- a/portfolio.csv
+++ b/portfolio.csv
@@ -1,0 +1,4 @@
+Symbol,Shares,Price
+AAPL,10,150.00
+GOOGL,5,2800.00
+TSLA,8,750.00

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <title>ポートフォリオ</title>
+  <style>
+    table { border-collapse: collapse; }
+    th, td { border:1px solid #ccc; padding:4px 8px; }
+  </style>
+</head>
+<body>
+  <h2>CSV ポートフォリオ</h2>
+  <table id="portfolio"></table>
+  <script>
+    fetch('portfolio.csv')
+      .then(response => response.text())
+      .then(text => {
+        const rows = text.trim().split(/\r?\n/).map(r => r.split(','));
+        const table = document.getElementById('portfolio');
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+        rows[0].forEach(h => {
+          const th = document.createElement('th');
+          th.textContent = h;
+          headerRow.appendChild(th);
+        });
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        rows.slice(1).forEach(r => {
+          const tr = document.createElement('tr');
+          r.forEach(c => {
+            const td = document.createElement('td');
+            td.textContent = c;
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document how to use new CSV-driven portfolio page
- provide sample `portfolio.csv`
- add `portfolio.html` that loads the CSV and renders a table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b246a2de24832b8213492b0ec696eb