### PR TITLE
Add D1-backed portfolio API and update client

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -9,17 +9,16 @@
   </style>
 </head>
 <body>
-  <h2>CSV ポートフォリオ</h2>
+  <h2>ポートフォリオ</h2>
   <table id="portfolio"></table>
   <script>
-    fetch('portfolio.csv')
-      .then(response => response.text())
-      .then(text => {
-        const rows = text.trim().split(/\r?\n/).map(r => r.split(','));
+    fetch('/api/portfolio')
+      .then(response => response.json())
+      .then(rows => {
         const table = document.getElementById('portfolio');
         const thead = document.createElement('thead');
         const headerRow = document.createElement('tr');
-        rows[0].forEach(h => {
+        ['symbol', 'shares', 'currency'].forEach(h => {
           const th = document.createElement('th');
           th.textContent = h;
           headerRow.appendChild(th);
@@ -27,11 +26,11 @@
         thead.appendChild(headerRow);
         table.appendChild(thead);
         const tbody = document.createElement('tbody');
-        rows.slice(1).forEach(r => {
+        rows.forEach(r => {
           const tr = document.createElement('tr');
-          r.forEach(c => {
+          ['symbol', 'shares', 'currency'].forEach(k => {
             const td = document.createElement('td');
-            td.textContent = c;
+            td.textContent = r[k];
             tr.appendChild(td);
           });
           tbody.appendChild(tr);

--- a/report.html
+++ b/report.html
@@ -103,18 +103,11 @@
           });
         });
       };
-      function parseCSV(text){
-        return text.trim().split(/\r?\n/).slice(1).map(function(line){
-          var parts = line.split(',');
-          return { symbol: (parts[0] || '').trim(), shares: parseFloat(parts[1] || '0') };
-        }).filter(function(r){ return r.symbol; });
-      }
       window.loadPortfolio = async function(){
         if (window.__pfLoaded) return;
         try{
-          var res = await fetch('portfolio.csv');
-          var txt = await res.text();
-          var rows = parseCSV(txt);
+          var res = await fetch('/api/portfolio');
+          var rows = await res.json();
           var jpyBody = document.querySelector('#pf-table-jpy tbody');
           var usdBody = document.querySelector('#pf-table-usd tbody');
           rows.forEach(function(r){

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS holdings (
+  symbol TEXT PRIMARY KEY,
+  shares REAL NOT NULL,
+  currency TEXT
+);


### PR DESCRIPTION
## Summary
- define `holdings` table schema for Cloudflare D1
- expose `/api/portfolio` worker route with basic CRUD
- load portfolio via API in HTML pages and Python script
- document new API workflow in README

## Testing
- `node --check proxy/worker.js`
- `python -m py_compile portfolio_notify.py`
- `npx --yes wrangler d1 create stock-db` *(fails: login required)*

------
https://chatgpt.com/codex/tasks/task_e_68b251600e40832b915db25ab98ee9e3