### PR TITLE
Configure Cloudflare Worker with D1 database

### DIFF
--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -1,0 +1,9 @@
+name = "stock-proxy"
+main = "worker.js"
+compatibility_date = "2024-04-19"
+
+[[d1_databases]]
+# Replace with your actual D1 database name and ID
+binding = "DB"
+database_name = "stock-db"
+database_id = "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary
- add Wrangler config binding the worker to a D1 database
- worker exposes `/api/portfolio` for reading and mutating holdings
- front-end pages and Python tool consume the portfolio via the new API

## Testing
- `node --check proxy/worker.js`
- `python -m py_compile portfolio_notify.py`
- `wrangler d1 create stock-db` *(fails: OAuth login required)*

------
https://chatgpt.com/codex/tasks/task_e_68b257075428832b9c06c4984bcfecc3