### PR TITLE
Configure D1 database for worker

### DIFF
--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -6,4 +6,4 @@ compatibility_date = "2024-04-19"
 # Replace with your actual D1 database name and ID
 binding = "DB"
 database_name = "stock-db"
-database_id = "00000000-0000-0000-0000-000000000000"
+database_id = "622ab108-c7b6-4df9-a481-766b7e9a4b30"


### PR DESCRIPTION
## Summary
- configure `proxy/wrangler.toml` with the new Cloudflare D1 database ID

## Testing
- `wrangler d1 execute stock-db --file=../schema.sql` *(local)*
- `wrangler d1 execute stock-db --file=../schema.sql --remote` *(fails: Timed out waiting for authorization code)*
- `wrangler deploy` *(fails: Timed out waiting for authorization code)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ad6e28c832ba24f0c92c8dd97b6